### PR TITLE
fix(overlay): exclude windows with WS_CAPTION from rect-based fullscr…

### DIFF
--- a/OverlayWindow.cs
+++ b/OverlayWindow.cs
@@ -343,8 +343,13 @@ namespace Kil0bitSystemMonitor
                 // fire ABN_FULLSCREENAPP (most modern titles, browser F11, video players, etc.)
                 if (fg != IntPtr.Zero && fg != _hWnd)
                 {
+                    // Maximized windows on no-taskbar displays cover the full monitor rect; require borderless to qualify as fullscreen.
+                    const long WS_CAPTION = 0x00C00000L;
+                    long style = Win32Helper.GetWindowLong(fg, Win32Helper.GWL_STYLE);
+                    bool hasCaption = (style & WS_CAPTION) != 0;
+
                     // Check if foreground window covers the whole monitor
-                    if (Win32Helper.GetWindowRect(fg, out Win32Helper.RECT fgRect))
+                    if (!hasCaption && Win32Helper.GetWindowRect(fg, out Win32Helper.RECT fgRect))
                     {
                         IntPtr hMon = MonitorFromWindow(fg, 1); // MONITOR_DEFAULTTONEAREST
                         MONITORINFO mi = new MONITORINFO { cbSize = (uint)Marshal.SizeOf(typeof(MONITORINFO)) };


### PR DESCRIPTION
## Problem

With "Hide in Fullscreen" enabled, the overlay fades whenever focus moves to a maximized window on a secondary monitor that has no taskbar.

The rect-based fullscreen fallback in `ShouldShowOverlay()` (added to catch borderless windowed-fullscreen games that don't fire `ABN_FULLSCREENAPP`) considers any foreground window whose rect covers the full monitor as fullscreen. On a no-taskbar display, a normal maximized window covers the full monitor rect, because the OS has no taskbar work area to subtract.

## Repro

1. Single-taskbar Windows setup: Personalization → Taskbar → "Show my taskbar on all displays" = off
2. Enable "Hide in Fullscreen" in the overlay context menu
3. Maximize any normal window on the secondary monitor
4. Overlay fades

## Fix

Check `WS_CAPTION` before applying the rect-based heuristic. Borderless fullscreen / windowed-fullscreen games never have `WS_CAPTION`, so they still trigger the hide. Normal maximized windows (which always have a title bar) are excluded.

`ABN_FULLSCREENAPP`, the taskbar-collapse check, F11 browser, and Task View behavior are unchanged.

## Diff

6 inserts, 1 modified line. Reuses `Win32Helper.GetWindowLong` + `Win32Helper.GWL_STYLE` already declared in the project.