### PR TITLE
feat(telemetry): add GPU VRAM monitoring for the selected GPU

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -23,6 +23,7 @@ The overlay is a slim, elegant pill that sits directly on your **Windows 11 task
 - **RAM**: Real-time memory pressure.
 - **NET**: Combined Upload and Download speeds.
 - **GPU**: Raw load and temperatures from your graphics processor.
+- **VRAM**: Dedicated memory usage (used / total) for the selected GPU. *(Off by default — enable in Monitoring settings; pick Percent or Used / Total format in Appearance.)*
 - **DISK**: Real-time activity and storage usage for multiple drives simultaneously.
 
 ### 🖱️ Overlay Controls

--- a/Models/SystemMetrics.cs
+++ b/Models/SystemMetrics.cs
@@ -16,6 +16,9 @@ namespace Kil0bitSystemMonitor.Models
         public float RamPercent { get; set; }
         public float GpuUsage { get; set; }
         public float GpuTemperature { get; set; }
+        public float VramPercent { get; set; }
+        public ulong VramUsedBytes { get; set; }
+        public ulong VramTotalBytes { get; set; }
         public float NetUpKbps { get; set; }
         public float NetDownKbps { get; set; }
         public string NetUpText { get; set; } = "0 KB/s";
@@ -34,6 +37,7 @@ namespace Kil0bitSystemMonitor.Models
         private bool _showRam = true;
         private bool _showGpu = true;
         private bool _showTemp = true;
+        private bool _showVram = false;
         private bool _showDisk = true;
         private bool _showDiskSpeed = true;
         private bool _showNetUp = true;
@@ -42,6 +46,7 @@ namespace Kil0bitSystemMonitor.Models
         private string _gpuAdapter = "Default";
         private string _selectedDisks = "All";
         private string _displayStyle = "Text";
+        private string _vramDisplayStyle = "Percent";
         private string _fontFamily = "Segoe UI";
         private string _accentColorHex = "#FFFFFF";
         private string _labelColorHex = "#00CCFF";
@@ -81,6 +86,7 @@ namespace Kil0bitSystemMonitor.Models
         public bool ShowRam { get => _showRam; set { _showRam = value; OnPropertyChanged(); } }
         public bool ShowGpu { get => _showGpu; set { _showGpu = value; OnPropertyChanged(); } }
         public bool ShowTemp { get => _showTemp; set { _showTemp = value; OnPropertyChanged(); } }
+        public bool ShowVram { get => _showVram; set { _showVram = value; OnPropertyChanged(); } }
         public bool ShowDisk { get => _showDisk; set { _showDisk = value; OnPropertyChanged(); } }
         public bool ShowDiskSpeed { get => _showDiskSpeed; set { _showDiskSpeed = value; OnPropertyChanged(); } }
         public bool ShowNetUp { get => _showNetUp; set { _showNetUp = value; OnPropertyChanged(); } }
@@ -90,6 +96,7 @@ namespace Kil0bitSystemMonitor.Models
         public string GpuAdapter { get => _gpuAdapter; set { _gpuAdapter = value; OnPropertyChanged(); } }
         public string SelectedDisks { get => _selectedDisks; set { _selectedDisks = value; OnPropertyChanged(); } }
         public string DisplayStyle { get => _displayStyle; set { _displayStyle = value; OnPropertyChanged(); } }
+        public string VramDisplayStyle { get => _vramDisplayStyle; set { _vramDisplayStyle = value; OnPropertyChanged(); } }
         public string FontFamily { get => _fontFamily; set { _fontFamily = value; OnPropertyChanged(); } }
 
         public string AccentColorHex { get => _accentColorHex; set { _accentColorHex = value; OnPropertyChanged(); OnPropertyChanged(nameof(AccentColor)); } }

--- a/OverlayWindow.cs
+++ b/OverlayWindow.cs
@@ -511,14 +511,14 @@ namespace Kil0bitSystemMonitor
                     { _offscreenGraphics.FillPath(pBrush, path); _offscreenGraphics.DrawPath(pPen, path); }
                 }
 
-                // Pick the correct label and accent brushes for this column index
-                Brush sectionLBrush = i == 0 ? netLBrush
-                                    : i == 1 ? cpuLBrush
-                                    : i == 2 ? gpuLBrush
+                // Pick the correct label and accent brushes for this column's section
+                Brush sectionLBrush = col.Section == SectionNet    ? netLBrush
+                                    : col.Section == SectionCpuRam ? cpuLBrush
+                                    : col.Section == SectionGpu    ? gpuLBrush
                                     : dskLBrush;
-                Brush sectionVBrush = i == 0 ? netVBrush
-                                    : i == 1 ? cpuVBrush
-                                    : i == 2 ? gpuVBrush
+                Brush sectionVBrush = col.Section == SectionNet    ? netVBrush
+                                    : col.Section == SectionCpuRam ? cpuVBrush
+                                    : col.Section == SectionGpu    ? gpuVBrush
                                     : dskVBrush;
 
                 float contentX = cx + pad;
@@ -557,7 +557,10 @@ namespace Kil0bitSystemMonitor
             return $"{kbps:F0} KB/s";
         }
 
-        private System.Collections.Generic.List<(MetricItem? Top, MetricItem? Bottom)> PrepareMetricsData()
+        // Section indices for per-section brush lookup: 0=Net, 1=CPU/RAM, 2=GPU, 3=Disk
+        private const int SectionNet = 0, SectionCpuRam = 1, SectionGpu = 2, SectionDisk = 3;
+
+        private System.Collections.Generic.List<(MetricItem? Top, MetricItem? Bottom, int Section)> PrepareMetricsData()
         {
             bool compact = (_config.Config.DisplayStyle ?? "Text") == "Compact";
             var m = _viewModel.Metrics; var c = _config.Config;
@@ -567,17 +570,34 @@ namespace Kil0bitSystemMonitor
             // Reserve "1023 MB/s": widest net format before switching to GB/s (M glyph is wider than K)
             MetricItem Net(string f, string cp, string v)  => new MetricItem { Label = compact ? cp : f, Value = v, Reserve = "1023 MB/s" };
 
-            var list = new System.Collections.Generic.List<(MetricItem?, MetricItem?)>();
+            var list = new System.Collections.Generic.List<(MetricItem?, MetricItem?, int)>();
 
             if (c.ShowNetUp || c.ShowNetDown)
-                list.Add((c.ShowNetUp ? Net("UP ", "U", m.NetUpText) : null, c.ShowNetDown ? Net("DN ", "D", m.NetDownText) : null));
+                list.Add((c.ShowNetUp ? Net("UP ", "U", m.NetUpText) : null, c.ShowNetDown ? Net("DN ", "D", m.NetDownText) : null, SectionNet));
 
             if (c.ShowCpu || c.ShowRam)
-                list.Add((c.ShowCpu ? Pct("CPU", "C", $"{(int)m.CpuUsage}%") : null, c.ShowRam ? Pct("RAM", "R", $"{(int)m.RamPercent}%") : null));
+                list.Add((c.ShowCpu ? Pct("CPU", "C", $"{(int)m.CpuUsage}%") : null, c.ShowRam ? Pct("RAM", "R", $"{(int)m.RamPercent}%") : null, SectionCpuRam));
 
             string tempStr = m.GpuTemperature > 0 ? $"{(int)m.GpuTemperature}°" : "N/A";
             if (c.ShowGpu || c.ShowTemp)
-                list.Add((c.ShowGpu ? Pct("GPU", "G", $"{(int)m.GpuUsage}%") : null, c.ShowTemp ? Temp("TMP", "T", tempStr) : null));
+                list.Add((c.ShowGpu ? Pct("GPU", "G", $"{(int)m.GpuUsage}%") : null, c.ShowTemp ? Temp("TMP", "T", tempStr) : null, SectionGpu));
+
+            if (c.ShowVram)
+            {
+                MetricItem vram;
+                if (m.VramTotalBytes > 0 && (c.VramDisplayStyle ?? "Percent") == "Used / Total")
+                {
+                    float usedGb = m.VramUsedBytes / 1073741824f;
+                    float totalGb = m.VramTotalBytes / 1073741824f;
+                    // Reserve the used field at full capacity so the column never resizes
+                    vram = new MetricItem { Label = compact ? "V" : "VRM", Value = $"{usedGb:F1}/{totalGb:F1} GB", Reserve = $"{totalGb:F1}/{totalGb:F1} GB" };
+                }
+                else
+                {
+                    vram = new MetricItem { Label = compact ? "V" : "VRM", Value = m.VramTotalBytes > 0 ? $"{(int)m.VramPercent}%" : "N/A", Reserve = "100%" };
+                }
+                list.Add((vram, null, SectionGpu));
+            }
 
             if (c.ShowDisk || c.ShowDiskSpeed)
             {
@@ -595,7 +615,8 @@ namespace Kil0bitSystemMonitor
 
                         list.Add((
                             c.ShowDisk ? Pct(cdkLabel, letter, $"{(int)d.SpacePercent}%") : null,
-                            c.ShowDiskSpeed ? Pct("SPD", "S", $"{(int)d.ActivityPercent}%") : null
+                            c.ShowDiskSpeed ? Pct("SPD", "S", $"{(int)d.ActivityPercent}%") : null,
+                            SectionDisk
                         ));
                     }
                 }

--- a/Services/TelemetryService.cs
+++ b/Services/TelemetryService.cs
@@ -37,6 +37,9 @@ namespace Kil0bitSystemMonitor.Services
         private System.Net.NetworkInformation.NetworkInterface[]? _cachedNetworkInterfaces;
         private DateTime _lastNetworkRefresh = DateTime.MinValue;
         private DateTime _lastGpuCounterRefresh = DateTime.MinValue;
+        private PerformanceCounter? _vramCounter;
+        private ulong _vramTotalBytes;
+        private DateTime _lastVramRefresh = DateTime.MinValue;
 
         public event Action<SystemMetrics>? MetricsUpdated;
 
@@ -275,7 +278,8 @@ namespace Kil0bitSystemMonitor.Services
 
                 // Initial update of counters
                 UpdateGpuCounters();
-                
+                InitializeVram();
+
                 StartSmiReader();
                 _adlService?.Dispose();
                 _adlService = new AmdAdlService(selectedName);
@@ -355,6 +359,91 @@ namespace Kil0bitSystemMonitor.Services
                 foreach (var r in toRemove) { _gpuCounters[r].Dispose(); _gpuCounters.Remove(r); }
             }
             catch { }
+        }
+
+        private void InitializeVram()
+        {
+            try
+            {
+                _vramCounter?.Dispose();
+                _vramCounter = null;
+                _vramTotalBytes = 0;
+                _lastVramRefresh = DateTime.Now;
+                if (!_config.Config.ShowVram) return;
+
+                var category = new PerformanceCounterCategory("GPU Adapter Memory");
+                var instances = category.GetInstanceNames();
+
+                // Prefer the selected GPU's LUID; otherwise pick the adapter with the most dedicated VRAM
+                string? instance = null;
+                if (_selectedGpuLuid != null)
+                    instance = instances.FirstOrDefault(i => i.ToLowerInvariant().Contains(_selectedGpuLuid));
+                if (instance == null)
+                {
+                    ulong best = 0;
+                    foreach (var inst in instances)
+                    {
+                        ulong dedicated = GetVramSegmentSizes(inst).dedicated;
+                        if (dedicated > best) { best = dedicated; instance = inst; }
+                    }
+                }
+                if (instance == null) return;
+
+                var (dedicatedSize, sharedSize) = GetVramSegmentSizes(instance);
+                // Integrated GPUs without a dedicated carve-out expose their memory as Shared
+                bool useDedicated = dedicatedSize > 0;
+                _vramTotalBytes = useDedicated ? dedicatedSize : sharedSize;
+                if (_vramTotalBytes == 0) return;
+                _vramCounter = new PerformanceCounter("GPU Adapter Memory", useDedicated ? "Dedicated Usage" : "Shared Usage", instance);
+            }
+            catch { _vramCounter = null; _vramTotalBytes = 0; }
+        }
+
+        // Total VRAM via D3DKMT segment sizes (vendor-neutral, no admin).
+        // Counter instance format is "luid_0x<HighPart>_0x<LowPart>_phys_0".
+        private static (ulong dedicated, ulong shared) GetVramSegmentSizes(string counterInstance)
+        {
+            try
+            {
+                var parts = counterInstance.ToLowerInvariant().Split('_');
+                int lIdx = Array.IndexOf(parts, "luid");
+                if (lIdx < 0 || lIdx + 2 >= parts.Length) return (0, 0);
+
+                var openLuid = new D3DKMT_OPENADAPTERFROMLUID();
+                openLuid.AdapterLuid.HighPart = int.Parse(parts[lIdx + 1].Replace("0x", ""), System.Globalization.NumberStyles.HexNumber);
+                openLuid.AdapterLuid.LowPart = uint.Parse(parts[lIdx + 2].Replace("0x", ""), System.Globalization.NumberStyles.HexNumber);
+                if (D3DKMTOpenAdapterFromLuid(ref openLuid) != 0) return (0, 0);
+
+                ulong dedicated = 0, shared = 0;
+                var sizeInfo = new D3DKMT_SEGMENTSIZEINFO();
+                int structSize = Marshal.SizeOf(sizeInfo);
+                IntPtr pSizeInfo = Marshal.AllocHGlobal(structSize);
+                try
+                {
+                    Marshal.StructureToPtr(sizeInfo, pSizeInfo, false);
+                    var queryInfo = new D3DKMT_QUERYADAPTERINFO
+                    {
+                        hAdapter = openLuid.hAdapter,
+                        Type = KMTQUERYADAPTERINFOTYPE.KMTQAITYPE_GETSEGMENTSIZE,
+                        pPrivateDriverData = pSizeInfo,
+                        PrivateDriverDataSize = (uint)structSize
+                    };
+                    if (D3DKMTQueryAdapterInfo(ref queryInfo) == 0)
+                    {
+                        sizeInfo = Marshal.PtrToStructure<D3DKMT_SEGMENTSIZEINFO>(pSizeInfo);
+                        dedicated = sizeInfo.DedicatedVideoMemorySize;
+                        shared = sizeInfo.SharedSystemMemorySize;
+                    }
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(pSizeInfo);
+                    var closeAdapter = new D3DKMT_CLOSEADAPTER { hAdapter = openLuid.hAdapter };
+                    D3DKMTCloseAdapter(ref closeAdapter);
+                }
+                return (dedicated, shared);
+            }
+            catch { return (0, 0); }
         }
 
         private System.Collections.Generic.List<string> GetNvidiaGpus()
@@ -467,6 +556,34 @@ namespace Kil0bitSystemMonitor.Services
             }
             metrics.GpuUsage = gpuUsage;
 
+            // VRAM (used / total of the selected GPU)
+            if (_config.Config.ShowVram)
+            {
+                try
+                {
+                    // Throttled re-discovery, e.g. GPU added or driver reset killed the counter
+                    if (_vramCounter == null && (DateTime.Now - _lastVramRefresh).TotalSeconds >= 30)
+                        InitializeVram();
+
+                    if (_vramCounter != null && _vramTotalBytes > 0)
+                    {
+                        float used = _vramCounter.NextValue();
+                        if (used >= 0)
+                        {
+                            metrics.VramUsedBytes = (ulong)used;
+                            metrics.VramTotalBytes = _vramTotalBytes;
+                            metrics.VramPercent = Math.Min(100f, used / _vramTotalBytes * 100f);
+                        }
+                    }
+                }
+                catch
+                {
+                    // Counter died (GPU removed) — drop it; throttled re-init above will retry
+                    try { _vramCounter?.Dispose(); } catch { }
+                    _vramCounter = null;
+                }
+            }
+
             // Network
             var now = DateTime.Now;
             var netStats = GetNetworkStats();
@@ -550,6 +667,10 @@ namespace Kil0bitSystemMonitor.Services
             if (e.PropertyName == nameof(_config.Config.GpuIndex))
             {
                 InitializeGpu();
+            }
+            if (e.PropertyName == nameof(_config.Config.ShowVram))
+            {
+                InitializeVram();
             }
         }
 
@@ -906,7 +1027,16 @@ namespace Kil0bitSystemMonitor.Services
 
         private enum KMTQUERYADAPTERINFOTYPE
         {
+            KMTQAITYPE_GETSEGMENTSIZE = 3,
             KMTQAITYPE_ADAPTERPERFDATA = 35
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct D3DKMT_SEGMENTSIZEINFO
+        {
+            public ulong DedicatedVideoMemorySize;
+            public ulong DedicatedSystemMemorySize;
+            public ulong SharedSystemMemorySize;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -957,6 +1087,7 @@ namespace Kil0bitSystemMonitor.Services
                 _cpuCounter.Dispose();
                 foreach (var set in _diskCounters.Values) set.Dispose();
                 foreach (var c in _gpuCounters.Values) c.Dispose();
+                _vramCounter?.Dispose();
                 _adlService?.Dispose();
             }
             catch { }

--- a/SettingsWindow.xaml
+++ b/SettingsWindow.xaml
@@ -390,13 +390,21 @@
                                                     <TextBlock Text="GPU Usage" VerticalAlignment="Center" Opacity="0.8"/>
                                                     <ui:ToggleSwitch Grid.Column="1" IsOn="{Binding Config.ShowGpu, Mode=TwoWay}" OnContent="" OffContent="" Margin="10,0,0,0" />
                                                 </Grid>
-                                                <Grid>
+                                                <Grid Margin="0,0,0,12">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="130" />
                                                         <ColumnDefinition Width="Auto" />
                                                     </Grid.ColumnDefinitions>
                                                     <TextBlock Text="GPU Temperature" VerticalAlignment="Center" Opacity="0.8"/>
                                                     <ui:ToggleSwitch Grid.Column="1" IsOn="{Binding Config.ShowTemp, Mode=TwoWay}" OnContent="" OffContent="" Margin="10,0,0,0" />
+                                                </Grid>
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="130" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Text="VRAM Usage" VerticalAlignment="Center" Opacity="0.8"/>
+                                                    <ui:ToggleSwitch Grid.Column="1" IsOn="{Binding Config.ShowVram, Mode=TwoWay}" OnContent="" OffContent="" Margin="10,0,0,0" />
                                                 </Grid>
                                             </StackPanel>
                                         </Grid>
@@ -530,6 +538,12 @@
                                         <ComboBox SelectedValue="{Binding Config.DisplayStyle, Mode=TwoWay}" SelectedValuePath="Content" HorizontalAlignment="Stretch" Margin="0,0,0,16">
                                             <ComboBoxItem Content="Text" />
                                             <ComboBoxItem Content="Compact" />
+                                        </ComboBox>
+
+                                        <TextBlock Text="VRAM Format" FontWeight="SemiBold" FontSize="12" Opacity="0.7" Margin="0,0,0,8"/>
+                                        <ComboBox SelectedValue="{Binding Config.VramDisplayStyle, Mode=TwoWay}" SelectedValuePath="Content" HorizontalAlignment="Stretch" Margin="0,0,0,16">
+                                            <ComboBoxItem Content="Percent" />
+                                            <ComboBoxItem Content="Used / Total" />
                                         </ComboBox>
 
                                         <ui:ToggleSwitch Header="Bold Text" IsOn="{Binding Config.IsTextBold, Mode=TwoWay}" />

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -265,6 +265,7 @@ namespace Kil0bitSystemMonitor
         {
             var c = _config.Config;
             c.DisplayStyle = "Text";
+            c.VramDisplayStyle = "Percent";
             c.FontFamily = "Segoe UI";
             c.AccentColorHex = "#FFFFFF";
             c.LabelColorHex = "#00CCFF";
@@ -310,6 +311,7 @@ namespace Kil0bitSystemMonitor
             c.ShowRam = true;
             c.ShowGpu = true;
             c.ShowTemp = true;
+            c.ShowVram = false;
             c.ShowDisk = true;
             c.ShowDiskSpeed = true;
             c.ShowNetUp = true;
@@ -320,6 +322,7 @@ namespace Kil0bitSystemMonitor
             c.SelectedDisks = "All";
             
             c.DisplayStyle = "Text";
+            c.VramDisplayStyle = "Percent";
             c.FontFamily = "Segoe UI";
             c.AccentColorHex = "#FFFFFF";
             c.LabelColorHex = "#00CCFF";


### PR DESCRIPTION
Closes #42

## Summary

Adds a VRAM sensor showing used / total dedicated memory for the GPU selected in
Monitoring settings, as a new `VRM` column in the taskbar overlay.

- **Settings**: "VRAM Usage" toggle in Monitoring → Graphics & Thermals
  (**default OFF**, so existing setups are unchanged), plus a "VRAM Format"
  selector in Appearance → Typography: `Percent` (`VRM 62%`) or
  `Used / Total` (`VRM 12.3/31.4 GB`). Both persist via the existing
  `ConfigService` and switch live.
- **Overlay**: the column sits right after GPU/TMP, uses the GPU section
  colors, supports Compact mode (`V`), and reserves capacity width so the
  pill never resizes as values change.

## Why this API

The app advertises admin-less telemetry, so NVML/NVAPI/ADL-specific paths were
avoided in favor of OS-level sources that work without elevation on NVIDIA,
AMD, and Intel:

- **Used**: `"GPU Adapter Memory" → "Dedicated Usage"` performance counter
  (`"Shared Usage"` fallback for iGPUs without a dedicated carve-out), matched
  by the adapter LUID the telemetry service already resolves. This is the same
  source Task Manager uses for "Dedicated GPU memory", so the numbers line up.
- **Total**: `D3DKMTQueryAdapterInfo(KMTQAITYPE_GETSEGMENTSIZE)` — queried
  once per GPU init and cached; same `gdi32.dll` D3DKMT toolbox the
  temperature path already uses.

Performance: one extra `NextValue()` call on the existing telemetry timer —
no new polling loop, no per-tick allocations, and nothing is created or polled
while the toggle is off. Edge cases (no dedicated GPU, GPU removed/changed at
runtime, missing counters) degrade to `N/A` with throttled re-discovery (30 s),
never an exception. No new dependencies.

## Testing

Tested on Windows 11 with an RTX 5090 (+ Radeon iGPU):

- Used and total match Task Manager''s "Dedicated GPU memory" readout, and the
  value tracks live while loading AI models.
- Verified GPU selection switching (5090 ↔ iGPU ↔ Default), both display
  formats, Compact mode, persistence across restarts, and that the overlay is
  unchanged while the toggle is off.
- `dotnet build -c Release`: 0 warnings, 0 errors.

<img width="264" height="45" alt="image" src="https://github.com/user-attachments/assets/ee6d8e16-f506-435b-b169-07d224b822b1" />

---

Implemented with [Claude Code](https://claude.com/claude-code) and manually
reviewed and tested by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)