### PR TITLE
fix(telemetry): repair D3DKMT GPU temperature query

### DIFF
--- a/Services/TelemetryService.cs
+++ b/Services/TelemetryService.cs
@@ -657,10 +657,11 @@ namespace Kil0bitSystemMonitor.Services
                 {
                     try
                     {
+                        // Luid string format is "0x<HighPart>_0x<LowPart>" (from the perf counter instance names)
                         var parts = _selectedGpuLuid.Split('_');
-                        string lowStr = parts[0].Replace("0x", "");
-                        string highStr = parts[1].Replace("0x", "");
-                        
+                        string highStr = parts[0].Replace("0x", "");
+                        string lowStr = parts[1].Replace("0x", "");
+
                         var openLuid = new D3DKMT_OPENADAPTERFROMLUID();
                         openLuid.AdapterLuid.LowPart = uint.Parse(lowStr, System.Globalization.NumberStyles.HexNumber);
                         openLuid.AdapterLuid.HighPart = int.Parse(highStr, System.Globalization.NumberStyles.HexNumber);
@@ -906,7 +907,7 @@ namespace Kil0bitSystemMonitor.Services
 
         private enum KMTQUERYADAPTERINFOTYPE
         {
-            KMTQAITYPE_ADAPTERPERFDATA = 35
+            KMTQAITYPE_ADAPTERPERFDATA = 62
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -918,22 +919,20 @@ namespace Kil0bitSystemMonitor.Services
             public uint PrivateDriverDataSize;
         }
 
+        // Layout per d3dkmthk.h (WDDM 2.4+)
         [StructLayout(LayoutKind.Sequential)]
         private struct D3DKMT_ADAPTER_PERFDATA
         {
-            public uint ThermalThrottling;
-            public ulong CurrentFrequency;
-            public ulong MaxFrequency;
-            public ulong MaxFrequencyOC;
+            public uint PhysicalAdapterIndex; // in
             public ulong MemoryFrequency;
-            public ulong MemoryFrequencyOC;
-            public uint FanSpeed;
+            public ulong MaxMemoryFrequency;
+            public ulong MaxMemoryFrequencyOC;
+            public ulong MemoryBandwidth;
+            public ulong PCIEBandwidth;
+            public uint FanRPM;
+            public uint Power;
             public uint Temperature; // Deci-Celsius
-            public uint Voltage;
-            public uint MemoryUsage;
-            public uint MaxMemoryUsage;
-            public ulong CoreClock;
-            public ulong MemoryClock;
+            public byte PowerStateOverride;
         }
 
         [DllImport("gdi32.dll")]


### PR DESCRIPTION
Fixes #51

## Summary

The "Method 0.5: D3DKMT" path in `TelemetryService.GetGpuTemperature()` could
never return a temperature on any machine — it always failed silently and fell
through to the slower fallbacks (nvidia-smi process spawn, WMI queries). Three
independent bugs, all detailed in #51:

1. **Swapped LUID parts** — the luid string is `0x<HighPart>_0x<LowPart>`
   (from the perf counter instance names), but the code parsed the first
   component as LowPart. Since HighPart is virtually always `0x0`, this passed
   `LowPart = 0` and `D3DKMTOpenAdapterFromLuid` failed with
   `STATUS_INVALID_PARAMETER`.
2. **Wrong info type** — `KMTQAITYPE_ADAPTERPERFDATA` is `62` in
   `d3dkmthk.h`, not `35` (which is
   `KMTQAITYPE_QUERY_MULTIPLANEOVERLAY_DECODE_SUPPORT`).
3. **Mismatched struct layout** — `D3DKMT_ADAPTER_PERFDATA` did not match the
   WDK definition, so `Temperature` was read from the wrong offset. Replaced
   with the documented layout (`Temperature` remains deci-Celsius, so the
   existing `/ 10f` is unchanged).

With this fix the vendor-neutral, admin-less D3DKMT path works as intended,
so most users get their GPU temperature without spawning `nvidia-smi` or
falling back to WMI.

## Testing

- Verified on Windows 11 / RTX 5090 **without elevation** via the standalone
  P/Invoke repro from #51: corrected constants and layout return
  `Temperature = 480` → 48.0 °C (plausible idle), while the previous
  constants fail with `0xC000000D` at open (swapped LUID) and at query
  (type 35) respectively.
- `dotnet build -c Release`: 0 warnings, 0 errors.

Note: this branch is independent of #50, but both touch the
`KMTQUERYADAPTERINFOTYPE` enum block, so whichever merges second will have a
trivial one-line conflict there.

---

Implemented with [Claude Code](https://claude.com/claude-code) and manually
reviewed and tested by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)